### PR TITLE
Changes inside removed jinja expressions

### DIFF
--- a/server/src/DbtTextDocument.ts
+++ b/server/src/DbtTextDocument.ts
@@ -95,13 +95,8 @@ export class DbtTextDocument {
               if (!TextDocumentContentChangeEvent.isIncremental(c)) {
                 throw new Error('Incremental updates expected');
               }
-              const changeRange = {
-                startLine: c.range.start.line,
-                startPosition: c.range.start.character,
-                endLine: c.range.end.line,
-                endPosition: c.range.end.character,
-              };
-              return Diff.isRangeInsideAnother(changeRange, r);
+              const changeRange = Range.create(c.range.start.line, c.range.start.character, c.range.end.line, c.range.end.character);
+              return !Diff.rangesEquals(changeRange, r) && Diff.rangeContains(changeRange, r);
             }),
         )
         .map(c => {

--- a/server/src/Diff.ts
+++ b/server/src/Diff.ts
@@ -1,11 +1,5 @@
 import * as fastDiff from 'fast-diff';
-
-export interface Range {
-  startLine: number;
-  startPosition: number;
-  endLine: number;
-  endPosition: number;
-}
+import { Range } from 'vscode-languageserver';
 
 export class Diff {
   static getRemovedRanges(oldString: string, newString: string): Range[] {
@@ -37,12 +31,7 @@ export class Diff {
       }
 
       if (diffType === fastDiff.DELETE) {
-        result.push({
-          startLine: currentLine,
-          startPosition: currentPosition,
-          endLine: nextLine,
-          endPosition: nextPosition,
-        });
+        result.push(Range.create(currentLine, currentPosition, nextLine, nextPosition));
       }
 
       currentLine = nextLine;
@@ -108,10 +97,19 @@ export class Diff {
     return lastLineBreak == -1 ? str.length : str.length - lastLineBreak - 1;
   }
 
-  static isRangeInsideAnother(test: Range, range: Range): boolean {
+  static rangesEquals(first: Range, second: Range): boolean {
     return (
-      (test.startLine > range.startLine || (test.startLine == range.startLine && test.startPosition >= range.startPosition)) &&
-      (test.endLine < range.endLine || (test.endLine == range.endLine && test.endPosition <= range.endPosition))
+      first.start.line == second.start.line &&
+      first.start.character == second.start.character &&
+      first.end.line == second.end.line &&
+      first.end.character == second.end.character
+    );
+  }
+
+  static rangeContains(inner: Range, outer: Range): boolean {
+    return (
+      (inner.start.line > outer.start.line || (inner.start.line == outer.start.line && inner.start.character >= outer.start.character)) &&
+      (inner.end.line < outer.end.line || (inner.end.line == outer.end.line && inner.end.character <= outer.end.character))
     );
   }
 }

--- a/server/src/Diff.ts
+++ b/server/src/Diff.ts
@@ -1,6 +1,57 @@
 import * as fastDiff from 'fast-diff';
 
+export interface Range {
+  startLine: number;
+  startPosition: number;
+  endLine: number;
+  endPosition: number;
+}
+
 export class Diff {
+  static getRemovedRanges(oldString: string, newString: string): Range[] {
+    const diffs = fastDiff(oldString, newString, 0);
+
+    if (!diffs || diffs.length === 0) {
+      return [];
+    }
+
+    const result = [];
+    let currentLine = 0;
+    let currentPosition = 0;
+    let nextLine: number;
+    let nextPosition: number;
+
+    for (let i = 0; i < diffs.length; i++) {
+      const diff = diffs[i];
+      const diffType = diff[0];
+      const diffText = diff[1];
+
+      if (diffType === fastDiff.DELETE || diffType === fastDiff.EQUAL) {
+        const diffLinesCount = this.getLinesCount(diffText);
+        const diffLastLineLength = this.getLastLineLength(diffText);
+
+        nextLine = currentLine + diffLinesCount;
+        nextPosition = diffLinesCount == 0 ? currentPosition + diffLastLineLength : diffLastLineLength;
+      } else {
+        continue;
+      }
+
+      if (diffType === fastDiff.DELETE) {
+        result.push({
+          startLine: currentLine,
+          startPosition: currentPosition,
+          endLine: nextLine,
+          endPosition: nextPosition,
+        });
+      }
+
+      currentLine = nextLine;
+      currentPosition = nextPosition;
+    }
+
+    return result;
+  }
+
   static getOldLineNumber(oldString: string, newString: string, newLineNumber: number): number {
     return this.getOldNumber(oldString, newString, newLineNumber, Diff.getLinesCount);
   }
@@ -50,5 +101,17 @@ export class Diff {
 
   static getLinesCount(str: string): number {
     return (str.match(/\n/g) || []).length;
+  }
+
+  static getLastLineLength(str: string): number {
+    const lastLineBreak = str.lastIndexOf('/n');
+    return lastLineBreak == -1 ? str.length : str.length - lastLineBreak - 1;
+  }
+
+  static isRangeInsideAnother(test: Range, range: Range): boolean {
+    return (
+      (test.startLine > range.startLine || (test.startLine == range.startLine && test.startPosition >= range.startPosition)) &&
+      (test.endLine < range.endLine || (test.endLine == range.endLine && test.endPosition <= range.endPosition))
+    );
   }
 }

--- a/server/src/Diff.ts
+++ b/server/src/Diff.ts
@@ -93,7 +93,7 @@ export class Diff {
   }
 
   static getLastLineLength(str: string): number {
-    const lastLineBreak = str.lastIndexOf('/n');
+    const lastLineBreak = str.lastIndexOf('\n');
     return lastLineBreak == -1 ? str.length : str.length - lastLineBreak - 1;
   }
 

--- a/server/src/test/Diff.spec.ts
+++ b/server/src/test/Diff.spec.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import { Diff } from '../Diff';
+import { Range } from 'vscode-languageserver';
 
 describe('Diff', () => {
   it('config_at_the_beginning', () => {
@@ -81,6 +82,25 @@ describe('Diff', () => {
 
   it('Should return char for not compiled line when jinja located at the beginning', () => {
     shouldReturnCorrespondingCharacterFor(' `project-abcde-400`.`transforms`.`table_volume_filled` t', ` {{ref('table_volume_filled')}} t`, [[0, 0]]);
+  });
+
+  it('Should return removed ranges', () => {
+    // arrange
+    const fileName = 'if';
+    const expectedRanges = [Range.create(0, 0, 8, 2), Range.create(43, 0, 43, 25), Range.create(46, 0, 46, 11)];
+
+    const filesRootPath = __dirname + '/../../src/test/diff/';
+    const raw = fs.readFileSync(`${filesRootPath}raw/${fileName}.sql`, 'utf8');
+    const compiled = fs.readFileSync(`${filesRootPath}compiled/${fileName}.sql`, 'utf8');
+
+    // act
+    const removedRanges = Diff.getRemovedRanges(raw, compiled);
+
+    // assert
+    assert.strictEqual(removedRanges.length, expectedRanges.length);
+    for (let i = 0; i < expectedRanges.length; i++) {
+      assert.strictEqual(Diff.rangesEquals(removedRanges[i], expectedRanges[i]), true);
+    }
   });
 
   function shouldReturnCorrespondingCharacterFor(oldLine: string, newLine: string, params: number[][]): void {


### PR DESCRIPTION
This PR prevents applying changes inside removed jinja expressions on query preview.
These changes are based on assumption that dbt compile removes mostly jinja blocks.
**Drawback**: Changes near removed jinjas are ignored.