### PR TITLE
Run Language Server for documents with sql-bigquery language id

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,9 +144,10 @@ jobs:
           python-version: '3.7.x'
 
       - name: add custom python venv with dbt@0.20.1
-        run: |
+        run: | # https://github.com/dbt-labs/dbt-core/issues/4745
           python -m venv ~/dbt_0_20_1_env
           ${{ matrix.activate-venv }}
+          pip install --force-reinstall MarkupSafe==2.0.1
           pip install dbt==0.20.1
           dbt --version
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,7 +147,7 @@ jobs:
         run: |
           python -m venv ~/dbt_0_20_1_env
           ${{ matrix.activate-venv }}
-          pip install dbt==0.20.1
+          pip install dbt==0.21.1
           dbt --version
 
       - name: prepare profile config

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,7 +147,7 @@ jobs:
         run: |
           python -m venv ~/dbt_0_20_1_env
           ${{ matrix.activate-venv }}
-          pip install dbt==0.21.1
+          pip install dbt==0.20.1
           dbt --version
 
       - name: prepare profile config

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,17 +64,17 @@ jobs:
       fail-fast: false
       matrix:
         include: # Run tests on latest version and version used in https://github.com/fivetran/analytics/blob/main/dbt_ft_prod/deployment.yml#L1
-          - dbt-version: 'pip install --force-reinstall MarkupSafe==2.0.1 && pip install dbt-bigquery==0.20.2'
+          - install-dbt: 'pip install --force-reinstall MarkupSafe==2.0.1 && pip install dbt-bigquery==0.20.2'
             os: macos-latest
             target: darwin-x64
             activate-venv: source ~/dbt_0_20_1_env/bin/activate
           
-          - dbt-version: 'pip install dbt-bigquery dbt-rpc'
+          - install-dbt: 'pip install dbt-bigquery dbt-rpc'
             os: macos-latest
             target: darwin-x64
             activate-venv: source ~/dbt_0_20_1_env/bin/activate
 
-          - dbt-version: 'pip install dbt-bigquery dbt-rpc'
+          - install-dbt: 'pip install dbt-bigquery dbt-rpc'
             os: ubuntu-latest
             target: linux-x64
             prepare-for-tests: |
@@ -83,7 +83,7 @@ jobs:
             activate-venv: source ~/dbt_0_20_1_env/bin/activate
 
           # TODO: enable this tests after implementing CLI support
-          # - dbt-version: 'dbt-bigquery dbt-rpc'
+          # - install-dbt: 'pip install dbt-bigquery dbt-rpc'
           #   os: windows-latest
           #   target: win32-x64
           #   add-colon-to-key-file-path: |
@@ -99,7 +99,7 @@ jobs:
           #     cd ~/dbt_0_20_1_env/Scripts
           #     . activate
 
-    name: e2e-${{ matrix.target }} ${{ matrix.dbt-version }} ${{ matrix.os }}
+    name: e2e-${{ matrix.target }} ${{ matrix.install-dbt }} ${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
     defaults:
@@ -221,7 +221,7 @@ jobs:
           ls -la
       
       - name: install dbt
-        run: ${{ matrix.dbt-version }}
+        run: ${{ matrix.install-dbt }}
 
       - name: show dbt info
         run: |
@@ -246,7 +246,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: e2e-${{ matrix.target }} ${{ matrix.dbt-version }} ${{ matrix.os }}
+          name: e2e-${{ matrix.target }} ${{ matrix.install-dbt }} ${{ matrix.os }}
           path: ./.vscode-test/user-data/logs/**/*dbt Language Support.log
 
   publish:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,17 +64,17 @@ jobs:
       fail-fast: false
       matrix:
         include: # Run tests on latest version and version used in https://github.com/fivetran/analytics/blob/main/dbt_ft_prod/deployment.yml#L1
-          - dbt-version: 'dbt-bigquery==0.20.2'
+          - dbt-version: 'pip install --force-reinstall MarkupSafe==2.0.1 && pip install dbt-bigquery==0.20.2'
             os: macos-latest
             target: darwin-x64
             activate-venv: source ~/dbt_0_20_1_env/bin/activate
           
-          - dbt-version: 'dbt-bigquery dbt-rpc'
+          - dbt-version: 'pip install dbt-bigquery dbt-rpc'
             os: macos-latest
             target: darwin-x64
             activate-venv: source ~/dbt_0_20_1_env/bin/activate
 
-          - dbt-version: 'dbt-bigquery dbt-rpc'
+          - dbt-version: 'pip install dbt-bigquery dbt-rpc'
             os: ubuntu-latest
             target: linux-x64
             prepare-for-tests: |
@@ -221,7 +221,7 @@ jobs:
           ls -la
       
       - name: install dbt
-        run: pip install ${{ matrix.dbt-version }}
+        run: ${{ matrix.dbt-version }}
 
       - name: show dbt info
         run: |

--- a/client/src/ExtensionClient.ts
+++ b/client/src/ExtensionClient.ts
@@ -18,7 +18,7 @@ import { TelemetryClient } from './TelemetryClient';
 import { WorkspaceHelper } from './WorkspaceHelper';
 import path = require('path');
 
-export const SUPPORTED_LANG_IDS = ['sql', 'jinja-sql'];
+export const SUPPORTED_LANG_IDS = ['sql', 'jinja-sql', 'sql-bigquery'];
 
 export class ExtensionClient {
   serverAbsolutePath: string;

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         {
           "submenu": "dbt",
           "group": "navigation",
-          "when": "editorLangId =~ /sql$/"
+          "when": "resourceExtname == .sql && !editorReadonly"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         {
           "submenu": "dbt",
           "group": "navigation",
-          "when": "resourceExtname == .sql && !editorReadonly"
+          "when": "editorLangId =~ /^sql$|^jinja-sql$|^sql-bigquery$/ && !editorReadonly"
         }
       ]
     },


### PR DESCRIPTION
- Run language server for documents with the next language ids: 'sql', 'jinja-sql', 'sql-bigquery';
- Don't show dbt Language Support options in preview window;