### PR TITLE
do not conflict with other extensions

### DIFF
--- a/e2e/src/dbt_packages.spec.ts
+++ b/e2e/src/dbt_packages.spec.ts
@@ -1,7 +1,7 @@
 import { assertThat, containsString } from 'hamjest';
 import { Position, Range, Uri } from 'vscode';
 import { assertDefinitions } from './asserts';
-import { activateAndWait, getCustomDocUri, getPreviewText, installDbtPackages, MAX_RANGE } from './helper';
+import { activateAndWait, getCustomDocUri, getPreviewText, installDbtPackages, MAX_RANGE, MIN_RANGE } from './helper';
 
 suite('Extension should work inside dbt package', () => {
   const PROJECT = 'project-with-packages';
@@ -50,7 +50,7 @@ suite('Extension should work inside dbt package', () => {
         originSelectionRange: new Range(3, 17, 3, 41),
         targetUri: findDocUriInPackage(`${MODELS_PATH}/tmp/stg_salesforce__user_tmp.sql`),
         targetRange: MAX_RANGE,
-        targetSelectionRange: MAX_RANGE,
+        targetSelectionRange: MIN_RANGE,
       },
     ]);
   });

--- a/e2e/src/dbt_packages.spec.ts
+++ b/e2e/src/dbt_packages.spec.ts
@@ -68,7 +68,7 @@ suite('Extension should work inside dbt package', () => {
         originSelectionRange: new Range(2, 17, 2, 38),
         targetUri: findDocUriInPackage('fivetran_utils/macros/get_columns_for_macro.sql'),
         targetRange: new Range(70, 0, 72, 15),
-        targetSelectionRange: new Range(70, 9, 70, 30),
+        targetSelectionRange: new Range(70, 9, 70, 9),
       },
     ]);
   });

--- a/e2e/src/definition.spec.ts
+++ b/e2e/src/definition.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import { Position, Range } from 'vscode';
 import { assertDefinitions } from './asserts';
-import { activateAndWait, getCustomDocUri, getDocUri, MAX_RANGE, TEST_FIXTURE_PATH } from './helper';
+import { activateAndWait, getCustomDocUri, getDocUri, MAX_RANGE, MIN_RANGE, TEST_FIXTURE_PATH } from './helper';
 import path = require('path');
 
 const REF_SQL_DOC_URI = getDocUri('ref_sql.sql');
@@ -15,7 +15,7 @@ suite('ref definitions', () => {
         originSelectionRange: new Range(1, 19, 1, 31),
         targetUri: getDocUri('table_exists.sql'),
         targetRange: MAX_RANGE,
-        targetSelectionRange: MAX_RANGE,
+        targetSelectionRange: MIN_RANGE,
       },
     ]);
   });
@@ -41,7 +41,7 @@ suite('ref definitions', () => {
         originSelectionRange: new Range(5, 37, 5, 49),
         targetUri: getDocUri('table_exists.sql'),
         targetRange: MAX_RANGE,
-        targetSelectionRange: MAX_RANGE,
+        targetSelectionRange: MIN_RANGE,
       },
     ]);
   });
@@ -55,7 +55,7 @@ suite('macro definitions', () => {
         originSelectionRange: new Range(2, 7, 2, 25),
         targetUri: getCustomDocUri('test-fixture/macros/name_utils.sql'),
         targetRange: new Range(0, 0, 2, 14),
-        targetSelectionRange: new Range(0, 9, 0, 27),
+        targetSelectionRange: new Range(0, 9, 0, 9),
       },
     ]);
     await assertDefinitions(PACKAGE_REF_DOC_URI, new Position(3, 9), [
@@ -63,7 +63,7 @@ suite('macro definitions', () => {
         originSelectionRange: new Range(3, 7, 3, 24),
         targetUri: getCustomDocUri('test-fixture/macros/name_utils.sql'),
         targetRange: new Range(4, 0, 6, 14),
-        targetSelectionRange: new Range(4, 9, 4, 26),
+        targetSelectionRange: new Range(4, 9, 4, 9),
       },
     ]);
   });

--- a/e2e/src/helper.ts
+++ b/e2e/src/helper.ts
@@ -32,6 +32,7 @@ export const PREVIEW_URI = 'query-preview:Preview?dbt-language-server';
 
 export const MAX_VSCODE_INTEGER = 2147483647;
 export const MAX_RANGE = new Range(0, 0, MAX_VSCODE_INTEGER, MAX_VSCODE_INTEGER);
+export const MIN_RANGE = new Range(0, 0, 0, 0);
 
 workspace.onDidChangeTextDocument(onDidChangeTextDocument);
 

--- a/e2e/src/postgres.spec.ts
+++ b/e2e/src/postgres.spec.ts
@@ -1,7 +1,7 @@
 import { assertThat, instanceOf } from 'hamjest';
 import { commands, MarkdownString, Position, Range, SignatureHelp } from 'vscode';
 import { assertDefinitions } from './asserts';
-import { activateAndWait, getCustomDocUri, getPreviewText, MAX_RANGE } from './helper';
+import { activateAndWait, getCustomDocUri, getPreviewText, MAX_RANGE, MIN_RANGE } from './helper';
 
 const ACTIVE_USERS_URI = getCustomDocUri('postgres/models/active_users.sql');
 const ORDERS_COUNT_DOC_URI = getCustomDocUri('postgres/models/active_users_orders_count.sql');
@@ -24,7 +24,7 @@ suite('Postgres destination', () => {
         originSelectionRange: new Range(1, 34, 1, 46),
         targetUri: ACTIVE_USERS_URI,
         targetRange: MAX_RANGE,
-        targetSelectionRange: MAX_RANGE,
+        targetSelectionRange: MIN_RANGE,
       },
     ]);
 
@@ -52,7 +52,7 @@ suite('Postgres destination', () => {
         originSelectionRange: new Range(0, 16, 0, 34),
         targetUri: getCustomDocUri('postgres/macros/name_parts.sql'),
         targetRange: new Range(0, 0, 2, 14),
-        targetSelectionRange: new Range(0, 9, 0, 27),
+        targetSelectionRange: new Range(0, 9, 0, 9),
       },
     ]);
   });

--- a/server/src/definition/DbtDefinitionProvider.ts
+++ b/server/src/definition/DbtDefinitionProvider.ts
@@ -12,6 +12,7 @@ export interface DbtNodeDefinitionProvider {
 
 export class DbtDefinitionProvider {
   static readonly MAX_RANGE = Range.create(0, 0, integer.MAX_VALUE, integer.MAX_VALUE);
+  static readonly MIN_RANGE = Range.create(0, 0, 0, 0);
 
   modelDefinitionProvider: ModelDefinitionProvider;
   macroDefinitionProvider: MacroDefinitionProvider;

--- a/server/src/definition/MacroDefinitionProvider.ts
+++ b/server/src/definition/MacroDefinitionProvider.ts
@@ -67,10 +67,8 @@ export class MacroDefinitionProvider implements DbtNodeDefinitionProvider {
         getPositionByIndex(macroDefinitionFileContent, startMacroMatch.index),
         getPositionByIndex(macroDefinitionFileContent, endMacroMatch.index + endMacroMatch[0].length),
       );
-      const selectionRange = Range.create(
-        getPositionByIndex(macroDefinitionFileContent, startMacroMatch.index + startMacroMatch[0].indexOf(macro)),
-        getPositionByIndex(macroDefinitionFileContent, startMacroMatch.index + startMacroMatch[0].indexOf(macro) + macro.length),
-      );
+      const keyWordPosition = getPositionByIndex(macroDefinitionFileContent, startMacroMatch.index + startMacroMatch[0].indexOf(macro));
+      const selectionRange = Range.create(keyWordPosition, keyWordPosition);
       return [definitionRange, selectionRange];
     }
 

--- a/server/src/definition/ModelDefinitionProvider.ts
+++ b/server/src/definition/ModelDefinitionProvider.ts
@@ -93,7 +93,7 @@ export class ModelDefinitionProvider implements DbtNodeDefinitionProvider {
         LocationLink.create(
           path.join(foundModel.rootPath, foundModel.originalFilePath),
           DbtDefinitionProvider.MAX_RANGE,
-          DbtDefinitionProvider.MAX_RANGE,
+          DbtDefinitionProvider.MIN_RANGE, // Decided to use the same range as other dbt extensions in order VS Code to filter equal values from definitions list (some details here: https://github.com/microsoft/vscode/issues/63895)
           modelSelectionRange,
         ),
       ];


### PR DESCRIPTION
https://fivetran.atlassian.net/browse/RD-259057
We show the same definitions as other extension, but since we format the result a bit different VS Code can't remove extra definitions. In this PR I made format similar.
https://github.com/microsoft/vscode/issues/63895