### PR TITLE
Sort manifest nodes

### DIFF
--- a/server/src/DbtRepository.ts
+++ b/server/src/DbtRepository.ts
@@ -106,12 +106,16 @@ export class DbtRepository {
 
   private sortManifestMacroNodes(): void {
     this.macros.sort((macro1: ManifestMacro, macro2: ManifestMacro): number => {
-      if (macro1.packageName === this.projectName) {
-        return 1;
+      if (macro1.packageName === this.projectName && macro2.packageName === this.projectName) {
+        return macro1.name.localeCompare(macro2.name);
       } else if (macro2.packageName === this.projectName) {
+        return 1;
+      } else if (macro1.packageName === this.projectName) {
         return -1;
       }
-      return 0;
+
+      const packagesCompare = macro2.packageName.localeCompare(macro1.packageName);
+      return packagesCompare === 0 ? macro1.name.localeCompare(macro2.name) : packagesCompare;
     });
   }
 }

--- a/server/src/DbtRepository.ts
+++ b/server/src/DbtRepository.ts
@@ -43,6 +43,7 @@ export class DbtRepository {
     this.sources = sources;
 
     this.groupManifestNodes();
+    this.sortManifestNodes();
   }
 
   private groupManifestNodes(): void {
@@ -97,5 +98,16 @@ export class DbtRepository {
       sourceTables.add(source);
     }
     this.packageToSources = newPackageToSources;
+  }
+
+  private sortManifestNodes(): void {
+    this.macros.sort((macro1: ManifestMacro, macro2: ManifestMacro): number => {
+      if (macro1.packageName === this.projectName) {
+        return 1;
+      } else if (macro2.packageName === this.projectName) {
+        return -1;
+      }
+      return 0;
+    });
   }
 }

--- a/server/src/DbtRepository.ts
+++ b/server/src/DbtRepository.ts
@@ -101,6 +101,10 @@ export class DbtRepository {
   }
 
   private sortManifestNodes(): void {
+    this.sortManifestMacroNodes();
+  }
+
+  private sortManifestMacroNodes(): void {
     this.macros.sort((macro1: ManifestMacro, macro2: ManifestMacro): number => {
       if (macro1.packageName === this.projectName) {
         return 1;


### PR DESCRIPTION
Macros completions e2e tests are failing time to time.
Additional logging on server side is a bit complicated due to the size of suggestions array.
This PR adds sorting of macros in order to solve this issue.