### PR TITLE
Lock preview group

### DIFF
--- a/client/src/ExtensionClient.ts
+++ b/client/src/ExtensionClient.ts
@@ -143,7 +143,11 @@ export class ExtensionClient {
       this.previewContentProvider.changeActiveDocument(editor.document.uri);
 
       const doc = await workspace.openTextDocument(SqlPreviewContentProvider.URI);
-      await window.showTextDocument(doc, ViewColumn.Beside, true);
+      const preserveFocus = window.visibleTextEditors.some(e => e.document.uri.path === SqlPreviewContentProvider.URI.path);
+      await window.showTextDocument(doc, ViewColumn.Beside, preserveFocus);
+      if (!preserveFocus) {
+        await commands.executeCommand('workbench.action.lockEditorGroup');
+      }
       await languages.setTextDocumentLanguage(doc, 'sql');
       this.previewContentProvider.updatePreviewDiagnostics(this.getDiagnostics());
     });

--- a/client/src/ExtensionClient.ts
+++ b/client/src/ExtensionClient.ts
@@ -147,6 +147,7 @@ export class ExtensionClient {
       await window.showTextDocument(doc, ViewColumn.Beside, preserveFocus);
       if (!preserveFocus) {
         await commands.executeCommand('workbench.action.lockEditorGroup');
+        await commands.executeCommand('workbench.action.focusPreviousGroup');
       }
       await languages.setTextDocumentLanguage(doc, 'sql');
       this.previewContentProvider.updatePreviewDiagnostics(this.getDiagnostics());


### PR DESCRIPTION
We now use [this feature](https://code.visualstudio.com/updates/v1_60#_locked-editor-groups) for Preview.