### PR TITLE
add qualify to reserved keywords

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,6 +27,7 @@
     "datetime",
     "dbname",
     "deps",
+    "devcontainers",
     "dremio",
     "duckdb",
     "dylib",

--- a/e2e/projects/test-fixture/models/complex_query.sql
+++ b/e2e/projects/test-fixture/models/complex_query.sql
@@ -8,6 +8,15 @@ with recursive referrers as (
     select u.id as used_id, rf.referrer_id as referrer_id
     from `singular-vector-135519.dbt_ls_e2e_dataset.users` u
         inner join referrers rf on u.referrer_id = rf.user_id
+), test as (
+    WITH Produce AS
+    (SELECT 'kale' as item, 23 as purchases, 'vegetable' as category)
+
+    SELECT
+        item,
+        rank() OVER (PARTITION BY category ORDER BY purchases DESC) as rank
+    FROM Produce
+        qualify rank <= 3
 )
 
 select 

--- a/server/src/ZetaSqlWrapper.ts
+++ b/server/src/ZetaSqlWrapper.ts
@@ -434,6 +434,7 @@ export class ZetaSqlWrapper {
         (await LanguageOptions.getLanguageFeaturesForVersion(LanguageVersion.VERSION_CURRENT)).forEach(f =>
           this.languageOptions?.enableLanguageFeature(f),
         );
+        this.languageOptions.options.reservedKeywords = ['QUALIFY'];
       } catch (e) {
         console.log(e instanceof Error ? e.stack : e);
       }

--- a/server/src/ZetaSqlWrapper.ts
+++ b/server/src/ZetaSqlWrapper.ts
@@ -434,6 +434,7 @@ export class ZetaSqlWrapper {
         (await LanguageOptions.getLanguageFeaturesForVersion(LanguageVersion.VERSION_CURRENT)).forEach(f =>
           this.languageOptions?.enableLanguageFeature(f),
         );
+        // https://github.com/google/zetasql/issues/115#issuecomment-1210881670
         this.languageOptions.options.reservedKeywords = ['QUALIFY'];
       } catch (e) {
         console.log(e instanceof Error ? e.stack : e);


### PR DESCRIPTION
Fix for such queries:
```
WITH Produce AS
 (SELECT 'kale' as item, 23 as purchases, 'vegetable' as category
 UNION ALL SELECT 'banana', 2, 'fruit'
 UNION ALL SELECT 'cabbage', 9, 'vegetable'
 UNION ALL SELECT 'apple', 8, 'fruit'
 UNION ALL SELECT 'leek', 2, 'vegetable'
 UNION ALL SELECT 'lettuce', 10, 'vegetable')
SELECT
 item,
 rank() OVER (PARTITION BY category ORDER BY purchases DESC) as rank
FROM Produce
--  WHERE Produce.category = 'vegetable'
 qualify ggg <= 3
```