### PR TITLE
show signature for different case

### DIFF
--- a/e2e/src/functions.spec.ts
+++ b/e2e/src/functions.spec.ts
@@ -10,7 +10,7 @@ suite('Functions', () => {
     // arrange
     await activateAndWait(DOC_URI);
 
-    await setTestContent('select max(');
+    await setTestContent('select Max(');
 
     // act
     const help = await vscode.commands.executeCommand<vscode.SignatureHelp>(
@@ -34,7 +34,7 @@ suite('Functions', () => {
     // arrange
     await activateAndWait(DOC_URI);
 
-    await setTestContent('select avg()');
+    await setTestContent('select Avg()');
 
     // act
     await vscode.commands.executeCommand('editor.afterFunctionCompletion');
@@ -48,7 +48,7 @@ suite('Functions', () => {
     // arrange
     await activateAndWait(DOC_URI);
 
-    await setTestContent('select coalesce');
+    await setTestContent('select Coalesce');
 
     // act
     const hovers = await vscode.commands.executeCommand<Hover[]>('vscode.executeHoverProvider', DOC_URI, new vscode.Position(0, 8));

--- a/server/src/HoverProvider.ts
+++ b/server/src/HoverProvider.ts
@@ -12,7 +12,7 @@ export class HoverProvider {
   signatureHelpProvider = new SignatureHelpProvider();
 
   hoverOnText(text: string, ast: AnalyzeResponse | undefined): Hover | null {
-    const index = HelpProviderWords.findIndex(w => w.name === text);
+    const index = HelpProviderWords.findIndex(w => w.name === text.toLocaleLowerCase());
     if (index !== -1) {
       const [firstSignature] = HelpProviderWords[index].signatures;
       return {

--- a/server/src/SignatureHelpProvider.ts
+++ b/server/src/SignatureHelpProvider.ts
@@ -13,7 +13,7 @@ export interface SignatureInfo {
 
 export class SignatureHelpProvider {
   onSignatureHelp(text: string): SignatureHelp | undefined {
-    const index = HelpProviderWords.findIndex(w => w.name === text);
+    const index = HelpProviderWords.findIndex(w => w.name === text.toLocaleLowerCase());
     if (index !== -1) {
       return {
         signatures: HelpProviderWords[index].signatures.map<SignatureInformation>(s => ({


### PR DESCRIPTION
We had problems when showing signature help for upper case: `MAX()`. In this PR I fixed it and modified tests for this cases.