### PR TITLE
refresh ZetaSQL catalog after changing model

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,26 +81,26 @@ jobs:
       fail-fast: false
       matrix:
         include: # Run tests on latest version and version used in https://github.com/fivetran/analytics/blob/main/dbt_ft_prod/deployment.yml#L1
-          - install-dbt: 'pip install dbt-core==1.0.4 dbt-bigquery==1.0.0 dbt-postgres==1.0.4 dbt-rpc'
+          - install-dbt: 'python -m pip install dbt-core==1.0.4 dbt-bigquery==1.0.0 dbt-postgres==1.0.4 dbt-rpc'
             os: macos-latest
             target: darwin-x64
             activate-venv: source ~/dbt_1_0_8_env/bin/activate
             python-version: '3.9.12'
 
-          - install-dbt: 'pip install dbt-bigquery dbt-postgres dbt-rpc'
+          - install-dbt: 'python -m pip install dbt-bigquery dbt-postgres dbt-rpc'
             os: macos-latest
             target: darwin-x64
             activate-venv: source ~/dbt_1_0_8_env/bin/activate
             python-version: '3.9.12'
 
-          - install-dbt: 'pip install dbt-bigquery dbt-postgres'
+          - install-dbt: 'python -m pip install dbt-bigquery dbt-postgres'
             os: macos-latest
             target: darwin-x64
             python-version: '3.10.5'
             use-dbt-cli: true
             SKIP_TESTS: 'certain_version.spec.js'
 
-          - install-dbt: 'pip install dbt-bigquery dbt-postgres dbt-rpc'
+          - install-dbt: 'python -m pip install dbt-bigquery dbt-postgres dbt-rpc'
             os: ubuntu-latest
             target: linux-x64
             prepare-for-tests: |
@@ -109,7 +109,7 @@ jobs:
             activate-venv: source ~/dbt_1_0_8_env/bin/activate
             python-version: '3.9.12'
 
-          - install-dbt: 'pip install dbt-bigquery dbt-postgres'
+          - install-dbt: 'python -m pip install dbt-bigquery dbt-postgres'
             os: windows-latest
             target: win32-x64
             add-colon-to-key-file-path: |
@@ -171,11 +171,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: show python info
-        run: |
-          python --version
-          python -m pip --version
 
       - name: add custom python venv with dbt@1.0.8
         if: matrix.python-version != '3.10.5'
@@ -280,8 +275,12 @@ jobs:
       - name: install dbt
         run: ${{ matrix.install-dbt }}
 
-      - name: show dbt info
+      - name: show info
         run: |
+          which python
+          python --version
+          python -m pip --version
+          python -m pip list | grep dbt
           which dbt
           dbt --version
           node -v

--- a/client/src/ActiveTextEditorHandler.ts
+++ b/client/src/ActiveTextEditorHandler.ts
@@ -1,0 +1,44 @@
+import { Disposable, TextEditor, window } from 'vscode';
+import { DbtLanguageClientManager } from './DbtLanguageClientManager';
+import { SUPPORTED_LANG_IDS } from './ExtensionClient';
+import SqlPreviewContentProvider from './SqlPreviewContentProvider';
+import { StatusHandler } from './status/StatusHandler';
+
+export class ActiveTextEditorHandler {
+  handler: Disposable;
+  lastActiveEditor?: TextEditor;
+
+  constructor(
+    private previewContentProvider: SqlPreviewContentProvider,
+    private dbtLanguageClientManager: DbtLanguageClientManager,
+    private statusHandler: StatusHandler,
+  ) {
+    this.handler = window.onDidChangeActiveTextEditor(this.onDidChangeActiveTextEditor.bind(this));
+  }
+
+  async onDidChangeActiveTextEditor(activeEditor: TextEditor | undefined): Promise<void> {
+    if (
+      !activeEditor ||
+      activeEditor.document.uri.path === SqlPreviewContentProvider.URI.path ||
+      !SUPPORTED_LANG_IDS.includes(activeEditor.document.languageId) ||
+      this.lastActiveEditor?.document.uri.path === activeEditor.document.uri.path
+    ) {
+      return;
+    }
+
+    this.lastActiveEditor = activeEditor;
+
+    this.previewContentProvider.changeActiveDocument(activeEditor.document.uri);
+
+    const client = await this.dbtLanguageClientManager.getClientByUri(activeEditor.document.uri);
+
+    if (client?.getProjectUri()) {
+      this.statusHandler.updateLanguageItems(client.getProjectUri().fsPath);
+    }
+    client?.resendDiagnostics(activeEditor.document.uri.toString());
+  }
+
+  dispose(): void {
+    this.handler.dispose();
+  }
+}

--- a/client/src/DbtLanguageClient.ts
+++ b/client/src/DbtLanguageClient.ts
@@ -117,6 +117,8 @@ export class DbtLanguageClient implements Disposable {
       dbtCompiler: workspace.getConfiguration('dbtWizard').get('dbtCompiler', 'Auto') as DbtCompilerType,
     };
 
+    this.client.clientOptions.outputChannel?.append(customInitParams.pythonInfo?.path ?? 'undefined');
+    this.client.clientOptions.outputChannel?.append(customInitParams.dbtCompiler);
     this.client.clientOptions.initializationOptions = customInitParams;
   }
 

--- a/client/src/DbtLanguageClient.ts
+++ b/client/src/DbtLanguageClient.ts
@@ -84,7 +84,6 @@ export class DbtLanguageClient implements Disposable {
         }
 
         this.previewContentProvider.updateDiagnostics(uri as string, diagnostics as Diagnostic[]);
-        this.previewContentProvider.applyDiagnostics(this.client.diagnostics);
       }),
 
       this.client.onNotification('custom/manifestParsed', () => {

--- a/client/src/DbtLanguageClient.ts
+++ b/client/src/DbtLanguageClient.ts
@@ -84,6 +84,7 @@ export class DbtLanguageClient implements Disposable {
         }
 
         this.previewContentProvider.updateDiagnostics(uri as string, diagnostics as Diagnostic[]);
+        this.previewContentProvider.applyDiagnostics(this.client.diagnostics);
       }),
 
       this.client.onNotification('custom/manifestParsed', () => {

--- a/client/src/DbtLanguageClientManager.ts
+++ b/client/src/DbtLanguageClientManager.ts
@@ -2,6 +2,7 @@ import EventEmitter = require('node:events');
 import { DiagnosticCollection, TextDocument, Uri, window, workspace } from 'vscode';
 import { DbtLanguageClient } from './DbtLanguageClient';
 import { ExtensionClient, SUPPORTED_LANG_IDS } from './ExtensionClient';
+import { log } from './Logger';
 import { OutputChannelProvider } from './OutputChannelProvider';
 import { ProgressHandler } from './ProgressHandler';
 import SqlPreviewContentProvider from './SqlPreviewContentProvider';
@@ -22,6 +23,7 @@ export class DbtLanguageClientManager {
   ) {}
 
   getDiagnostics(): DiagnosticCollection | undefined {
+    log('getDiagnostics');
     const [[, client]] = this.clients;
     return client.client.diagnostics;
   }
@@ -29,7 +31,7 @@ export class DbtLanguageClientManager {
   async getClientForActiveDocument(): Promise<DbtLanguageClient | undefined> {
     const document = this.getActiveDocument();
     if (document === undefined) {
-      console.log(`Can't find active document`);
+      log(`Can't find active document`);
       return undefined;
     }
 
@@ -57,6 +59,7 @@ export class DbtLanguageClientManager {
   }
 
   getClientByPath(projectPath: string): DbtLanguageClient | undefined {
+    log(`getClientByPath ${projectPath}`);
     return this.clients.get(projectPath);
   }
 
@@ -96,11 +99,10 @@ export class DbtLanguageClientManager {
     if (!projectUri) {
       return;
     }
-    this.outputChannelProvider
-      .getMainLogChannel()
-      .append(`Checking: ${document.uri.fsPath} + ${this.clients.has(projectUri.path) ? 'true' : 'false'}`);
+
+    log(`Checking: ${document.uri.fsPath} + ${this.clients.has(projectUri.path) ? 'true' : 'false'}`);
     if (!this.clients.has(projectUri.path)) {
-      this.outputChannelProvider.getMainLogChannel().append(`starting client for project ${projectUri.fsPath}`);
+      log(`starting client for project ${projectUri.fsPath}`);
 
       const client = new DbtLanguageClient(
         6009 + this.clients.size,
@@ -126,7 +128,7 @@ export class DbtLanguageClientManager {
     const client = this.getClientByPath(projectPath);
     if (client) {
       this.clients.delete(projectPath);
-      client.stop().catch(e => console.log(`Error while stopping client: ${e instanceof Error ? e.message : String(e)}`));
+      client.stop().catch(e => log(`Error while stopping client: ${e instanceof Error ? e.message : String(e)}`));
     }
   }
 

--- a/client/src/DbtLanguageClientManager.ts
+++ b/client/src/DbtLanguageClientManager.ts
@@ -23,9 +23,8 @@ export class DbtLanguageClientManager {
   ) {}
 
   getDiagnostics(): DiagnosticCollection | undefined {
-    log('getDiagnostics');
     const [[, client]] = this.clients;
-    return client.client.diagnostics;
+    return client.getDiagnostics();
   }
 
   async getClientForActiveDocument(): Promise<DbtLanguageClient | undefined> {
@@ -59,7 +58,6 @@ export class DbtLanguageClientManager {
   }
 
   getClientByPath(projectPath: string): DbtLanguageClient | undefined {
-    log(`getClientByPath ${projectPath}`);
     return this.clients.get(projectPath);
   }
 
@@ -100,10 +98,7 @@ export class DbtLanguageClientManager {
       return;
     }
 
-    log(`Checking: ${document.uri.fsPath} + ${this.clients.has(projectUri.path) ? 'true' : 'false'}`);
     if (!this.clients.has(projectUri.path)) {
-      log(`starting client for project ${projectUri.fsPath}`);
-
       const client = new DbtLanguageClient(
         6009 + this.clients.size,
         this.outputChannelProvider,

--- a/client/src/ExtensionClient.ts
+++ b/client/src/ExtensionClient.ts
@@ -60,7 +60,7 @@ export class ExtensionClient {
 
       workspace.onDidChangeTextDocument(e => {
         if (e.document.uri.path === SqlPreviewContentProvider.URI.path) {
-          this.previewContentProvider.updatePreviewDiagnostics(this.dbtLanguageClientManager.getDiagnostics());
+          this.previewContentProvider.applyDiagnostics(this.dbtLanguageClientManager.getDiagnostics());
         }
       }),
     );
@@ -113,7 +113,7 @@ export class ExtensionClient {
         await commands.executeCommand('workbench.action.focusPreviousGroup');
       }
       await languages.setTextDocumentLanguage(doc, 'sql');
-      this.previewContentProvider.updatePreviewDiagnostics(this.dbtLanguageClientManager.getDiagnostics());
+      this.previewContentProvider.applyDiagnostics(this.dbtLanguageClientManager.getDiagnostics());
     });
 
     context.subscriptions.push(this.previewContentProvider, commandRegistration, providerRegistrations);

--- a/client/src/ExtensionClient.ts
+++ b/client/src/ExtensionClient.ts
@@ -58,9 +58,9 @@ export class ExtensionClient {
         }
       }),
 
-      workspace.onDidChangeTextDocument(e => {
+      workspace.onDidChangeTextDocument(async e => {
         if (e.document.uri.path === SqlPreviewContentProvider.URI.path) {
-          this.previewContentProvider.applyDiagnostics(this.dbtLanguageClientManager.getDiagnostics());
+          await this.dbtLanguageClientManager.applyPreviewDiagnostics();
         }
       }),
     );
@@ -113,7 +113,7 @@ export class ExtensionClient {
         await commands.executeCommand('workbench.action.focusPreviousGroup');
       }
       await languages.setTextDocumentLanguage(doc, 'sql');
-      this.previewContentProvider.applyDiagnostics(this.dbtLanguageClientManager.getDiagnostics());
+      await this.dbtLanguageClientManager.applyPreviewDiagnostics();
     });
 
     context.subscriptions.push(this.previewContentProvider, commandRegistration, providerRegistrations);

--- a/client/src/ExtensionClient.ts
+++ b/client/src/ExtensionClient.ts
@@ -64,18 +64,19 @@ export class ExtensionClient {
       }),
 
       window.onDidChangeActiveTextEditor(async e => {
-        if (!e || e.document.uri.path === SqlPreviewContentProvider.URI.path) {
+        if (!e || e.document.uri.path === SqlPreviewContentProvider.URI.path || !SUPPORTED_LANG_IDS.includes(e.document.languageId)) {
           return;
         }
 
-        if (SUPPORTED_LANG_IDS.includes(e.document.languageId)) {
-          this.previewContentProvider.changeActiveDocument(e.document.uri);
+        this.previewContentProvider.changeActiveDocument(e.document.uri);
 
-          const projectFolder = await this.dbtLanguageClientManager.getDbtProjectUri(e.document.uri);
-          if (projectFolder) {
-            this.statusHandler.updateLanguageItems(projectFolder.path);
-          }
+        const projectFolder = await this.dbtLanguageClientManager.getDbtProjectUri(e.document.uri);
+        if (projectFolder) {
+          this.statusHandler.updateLanguageItems(projectFolder.path);
         }
+
+        const client = await this.dbtLanguageClientManager.getClientByUri(e.document.uri);
+        client?.sendNotification('dbtWizard/onDidChangeActiveTextEditor', e.document.uri.toString());
       }),
     );
     workspace.textDocuments.forEach(t =>

--- a/client/src/Logger.ts
+++ b/client/src/Logger.ts
@@ -1,0 +1,6 @@
+import { EOL } from 'os';
+import { outputChannelProvider } from './extension';
+
+export function log(message: string): void {
+  outputChannelProvider.getMainLogChannel().append(`Client ${new Date().toISOString()}: ${message}${EOL}`);
+}

--- a/client/src/ProgressHandler.ts
+++ b/client/src/ProgressHandler.ts
@@ -1,6 +1,7 @@
 import { deferred, DeferredResult } from 'dbt-language-server-common';
 import { ProgressLocation, window } from 'vscode';
 import { WorkDoneProgressBegin, WorkDoneProgressEnd, WorkDoneProgressReport } from 'vscode-languageserver-protocol';
+import { log } from './Logger';
 
 export class ProgressHandler {
   progressDeferred?: DeferredResult<void>;
@@ -15,7 +16,7 @@ export class ProgressHandler {
         this.progressDeferred = undefined;
         break;
       default:
-        console.log('Received event that is not supported');
+        log('Received event that is not supported');
         break;
     }
   }
@@ -33,7 +34,7 @@ export class ProgressHandler {
           },
           () => this.progressDeferred?.promise ?? Promise.resolve(),
         )
-        .then(undefined, e => console.log(e instanceof Error ? e.message : e));
+        .then(undefined, e => log(e instanceof Error ? e.message : String(e)));
     }
   }
 }

--- a/client/src/SqlPreviewContentProvider.ts
+++ b/client/src/SqlPreviewContentProvider.ts
@@ -65,7 +65,7 @@ export default class SqlPreviewContentProvider implements TextDocumentContentPro
     this.onDidChangeEmitter.fire(SqlPreviewContentProvider.URI);
   }
 
-  updatePreviewDiagnostics(diagnostics?: DiagnosticCollection): void {
+  applyDiagnostics(diagnostics?: DiagnosticCollection): void {
     const previewDiagnostics = this.previewInfos.get(this.activeDocUri.toString())?.diagnostics ?? [];
     diagnostics?.set(SqlPreviewContentProvider.URI, previewDiagnostics);
   }

--- a/client/src/SqlPreviewContentProvider.ts
+++ b/client/src/SqlPreviewContentProvider.ts
@@ -32,7 +32,9 @@ export default class SqlPreviewContentProvider implements TextDocumentContentPro
       diagnostics: currentValue?.diagnostics ?? [],
     });
 
-    this.onDidChangeEmitter.fire(SqlPreviewContentProvider.URI);
+    if (uri.toString() === this.activeDocUri.toString()) {
+      this.onDidChangeEmitter.fire(SqlPreviewContentProvider.URI);
+    }
   }
 
   updateDiagnostics(uri: string, diagnostics: Diagnostic[]): void {
@@ -69,8 +71,10 @@ export default class SqlPreviewContentProvider implements TextDocumentContentPro
   }
 
   changeActiveDocument(uri: Uri): void {
-    this.activeDocUri = uri;
-    this.onDidChangeEmitter.fire(SqlPreviewContentProvider.URI);
+    if (uri.toString() !== this.activeDocUri.toString()) {
+      this.activeDocUri = uri;
+      this.onDidChangeEmitter.fire(SqlPreviewContentProvider.URI);
+    }
   }
 
   dispose(): void {

--- a/client/src/SqlPreviewContentProvider.ts
+++ b/client/src/SqlPreviewContentProvider.ts
@@ -1,6 +1,5 @@
 import {
   Diagnostic,
-  DiagnosticCollection,
   DiagnosticRelatedInformation,
   DiagnosticSeverity,
   Event,
@@ -65,9 +64,8 @@ export default class SqlPreviewContentProvider implements TextDocumentContentPro
     this.onDidChangeEmitter.fire(SqlPreviewContentProvider.URI);
   }
 
-  applyDiagnostics(diagnostics?: DiagnosticCollection): void {
-    const previewDiagnostics = this.previewInfos.get(this.activeDocUri.toString())?.diagnostics ?? [];
-    diagnostics?.set(SqlPreviewContentProvider.URI, previewDiagnostics);
+  getPreviewDiagnostics(): Diagnostic[] {
+    return this.previewInfos.get(this.activeDocUri.toString())?.diagnostics ?? [];
   }
 
   changeActiveDocument(uri: Uri): void {

--- a/client/src/TelemetryClient.ts
+++ b/client/src/TelemetryClient.ts
@@ -1,6 +1,7 @@
 import TelemetryReporter, { TelemetryEventProperties } from '@vscode/extension-telemetry';
 import { ExtensionContext } from 'vscode';
 import { PackageJson } from './ExtensionClient';
+import { log } from './Logger';
 
 export class TelemetryClient {
   private static client: TelemetryReporter | undefined;
@@ -19,7 +20,7 @@ export class TelemetryClient {
 
   static activate(context: ExtensionContext, packageJson?: PackageJson): void {
     if (process.env['DBT_LS_DISABLE_TELEMETRY']) {
-      console.log('Telemetry is disabled');
+      log('Telemetry is disabled');
       return;
     }
 
@@ -27,7 +28,7 @@ export class TelemetryClient {
       TelemetryClient.client = new TelemetryReporter(packageJson.name, packageJson.version, packageJson.aiKey);
       context.subscriptions.push(TelemetryClient.client);
     } else {
-      console.log('Telemetry was not activated');
+      log('Telemetry was not activated');
     }
   }
 }

--- a/client/src/commands/InstallLatestDbt.ts
+++ b/client/src/commands/InstallLatestDbt.ts
@@ -1,5 +1,6 @@
 import { commands, window } from 'vscode';
 import { DbtLanguageClientManager } from '../DbtLanguageClientManager';
+import { log } from '../Logger';
 import { OutputChannelProvider } from '../OutputChannelProvider';
 import { Command } from './CommandManager';
 
@@ -25,7 +26,7 @@ export class InstallLatestDbt implements Command {
       }
     } else {
       window.showWarningMessage('First, open the model from the dbt project.').then(undefined, e => {
-        console.log(`Error while sending notification: ${e instanceof Error ? e.message : String(e)}`);
+        log(`Error while sending notification: ${e instanceof Error ? e.message : String(e)}`);
       });
     }
   }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,14 +1,16 @@
 import { ExtensionApi } from 'dbt-language-server-common/src/api/ExtensionApi';
 import { ExtensionContext } from 'vscode';
 import { ExtensionClient } from './ExtensionClient';
+import { OutputChannelProvider } from './OutputChannelProvider';
 import EventEmitter = require('node:events');
 
+export const outputChannelProvider = new OutputChannelProvider();
 let extensionClient: ExtensionClient;
 
 export function activate(context: ExtensionContext): ExtensionApi {
   const manifestParsedEventEmitter = new EventEmitter();
 
-  extensionClient = new ExtensionClient(context, manifestParsedEventEmitter);
+  extensionClient = new ExtensionClient(context, outputChannelProvider, manifestParsedEventEmitter);
   extensionClient.onActivate();
 
   return { manifestParsedEventEmitter };

--- a/client/src/python/PythonExtension.ts
+++ b/client/src/python/PythonExtension.ts
@@ -1,5 +1,6 @@
 import { PythonInfo } from 'dbt-language-server-common';
 import { Event, Extension, extensions, Uri, WorkspaceFolder } from 'vscode';
+import { log } from '../Logger';
 import { IExtensionApi, IProposedExtensionAPI } from './PythonApi';
 
 export class PythonExtension {
@@ -12,7 +13,7 @@ export class PythonExtension {
     }
     this.extension = extension;
 
-    this.activate().catch(e => console.log(`Error while activating Python extension: ${e instanceof Error ? e.message : String(e)}`));
+    this.activate().catch(e => log(`Error while activating Python extension: ${e instanceof Error ? e.message : String(e)}`));
   }
 
   async onDidChangeExecutionDetails(): Promise<Event<Uri | undefined>> {
@@ -36,7 +37,7 @@ export class PythonExtension {
     if (path === '') {
       return this.pythonNotFound();
     }
-    console.log(`Python path used: ${path}`);
+    log(`Python path used: ${path}`);
 
     const envDetails = await api.environment.getEnvironmentDetails(path);
 
@@ -50,7 +51,7 @@ export class PythonExtension {
   }
 
   pythonNotFound(): undefined {
-    console.log('ms-python.python not found');
+    log('ms-python.python not found');
     return undefined;
   }
 }

--- a/client/src/python/PythonExtension.ts
+++ b/client/src/python/PythonExtension.ts
@@ -37,7 +37,6 @@ export class PythonExtension {
     if (path === '') {
       return this.pythonNotFound();
     }
-    log(`Python path used: ${path}`);
 
     const envDetails = await api.environment.getEnvironmentDetails(path);
 

--- a/e2e/projects/test-fixture/models/compare_dates.sql
+++ b/e2e/projects/test-fixture/models/compare_dates.sql
@@ -1,0 +1,3 @@
+select new_date
+from {{ ref('my_new_project', 'table_does_not_exist') }}
+where new_date = date_sub(current_date(), interval 1 day)

--- a/e2e/projects/test-fixture/models/table_does_not_exist.sql
+++ b/e2e/projects/test-fixture/models/table_does_not_exist.sql
@@ -4,4 +4,4 @@
     materialized='table'
   ) 
 }}
-select 1 as id;
+select 1 as id, 2 as new_date;

--- a/e2e/src/asserts.ts
+++ b/e2e/src/asserts.ts
@@ -9,7 +9,7 @@ export async function assertAllDiagnostics(uri: Uri, diagnostics: Diagnostic[]):
 }
 
 export async function assertDiagnostics(uri: Uri, diagnostics: Diagnostic[]): Promise<void> {
-  await sleep(100);
+  await sleep(200);
 
   const rawDocDiagnostics = languages.getDiagnostics(uri);
   assertThat(rawDocDiagnostics, hasSize(diagnostics.length));

--- a/e2e/src/helper.ts
+++ b/e2e/src/helper.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs';
 import { writeFileSync } from 'fs';
 import * as path from 'path';
 import { pathEqual } from 'path-equal';
+import { setTimeout } from 'timers/promises';
 import {
   commands,
   CompletionItem,
@@ -23,7 +24,6 @@ import {
   window,
   workspace,
 } from 'vscode';
-
 export let doc: TextDocument;
 export let editor: TextEditor;
 
@@ -95,13 +95,8 @@ function onDidChangeTextDocument(e: TextDocumentChangeEvent): void {
   }
 }
 
-function waitWithTimeout(promise: Promise<void>, ms: number): Promise<void> {
-  const timeoutPromise = new Promise<void>(resolve => {
-    setTimeout(() => {
-      resolve();
-    }, ms);
-  });
-  return Promise.race([promise, timeoutPromise]);
+function waitWithTimeout(promise: Promise<void>, timeout: number): Promise<void> {
+  return Promise.race([promise, setTimeout(timeout)]);
 }
 
 export async function waitDocumentModification(func: () => Promise<void>): Promise<void> {
@@ -148,9 +143,7 @@ function getPreviewEditor(): TextEditor | undefined {
 }
 
 export function sleep(ms: number): Promise<unknown> {
-  return new Promise(resolve => {
-    setTimeout(resolve, ms);
-  });
+  return setTimeout(ms);
 }
 
 export const getDocPath = (p: string): string => {

--- a/e2e/src/helper.ts
+++ b/e2e/src/helper.ts
@@ -40,7 +40,7 @@ export const MAX_VSCODE_INTEGER = 2147483647;
 export const MAX_RANGE = new Range(0, 0, MAX_VSCODE_INTEGER, MAX_VSCODE_INTEGER);
 export const MIN_RANGE = new Range(0, 0, 0, 0);
 
-export const LS_MORE_THAN_OPEN_DEBOUNCE = 1100;
+export const LS_MORE_THAN_OPEN_DEBOUNCE = 1200;
 
 workspace.onDidChangeTextDocument(onDidChangeTextDocument);
 

--- a/e2e/src/runners/indexMain.ts
+++ b/e2e/src/runners/indexMain.ts
@@ -65,21 +65,19 @@ export async function indexMain(timeout: string, globPattern: string, doNotRun: 
 
       try {
         // Run the mocha test
-        const runner = mocha.run(failures => {
+        mocha.run(failures => {
           console.log(`E2E tests duration: ${(performance.now() - startTime) / 1000} seconds.`);
           if (failures > 0) {
+            try {
+              console.log(`Content of document when test failed:\n|${doc.getText()}|\n`);
+              console.log(`Preview content:\n|${getPreviewText()}|\n`);
+              console.log(`Preview diagnostics:\n|${JSON.stringify(languages.getDiagnostics(Uri.parse(PREVIEW_URI)))}|\n`);
+            } catch (err) {
+              console.log(`Error in fail stage: ${err instanceof Error ? err.message : String(err)}`);
+            }
             reject(new Error(`${failures} tests failed.`));
           } else {
             resolve();
-          }
-        });
-        runner.on('fail', () => {
-          try {
-            console.log(`Content of document when test failed:\n|${doc.getText()}|\n`);
-            console.log(`Preview content:\n|${getPreviewText()}|\n`);
-            console.log(`Preview diagnostics:\n|${JSON.stringify(languages.getDiagnostics(Uri.parse(PREVIEW_URI)))}|\n`);
-          } catch (err) {
-            // do nothing
           }
         });
       } catch (err) {

--- a/server/src/LspServer.ts
+++ b/server/src/LspServer.ts
@@ -214,7 +214,7 @@ export class LspServer {
     this.connection.onNotification('custom/dbtCompile', this.onDbtCompile.bind(this));
     this.connection.onNotification('dbtWizard/installLatestDbt', this.installLatestDbt.bind(this));
     this.connection.onNotification('dbtWizard/installDbtAdapter', this.installDbtAdapter.bind(this));
-    this.connection.onNotification('dbtWizard/onDidChangeActiveTextEditor', this.onDidChangeActiveTextEditor.bind(this));
+    this.connection.onNotification('dbtWizard/resendDiagnostics', this.onDidChangeActiveTextEditor.bind(this));
   }
 
   async onInitialized(): Promise<void> {

--- a/server/src/LspServer.ts
+++ b/server/src/LspServer.ts
@@ -214,6 +214,7 @@ export class LspServer {
     this.connection.onNotification('custom/dbtCompile', this.onDbtCompile.bind(this));
     this.connection.onNotification('dbtWizard/installLatestDbt', this.installLatestDbt.bind(this));
     this.connection.onNotification('dbtWizard/installDbtAdapter', this.installDbtAdapter.bind(this));
+    this.connection.onNotification('dbtWizard/onDidChangeActiveTextEditor', this.onDidChangeActiveTextEditor.bind(this));
   }
 
   async onInitialized(): Promise<void> {
@@ -332,6 +333,11 @@ export class LspServer {
           .catch(e => console.log(`Failed to send restart notification: ${e instanceof Error ? e.message : String(e)}`));
       }
     }
+  }
+
+  async onDidChangeActiveTextEditor(uri: string): Promise<void> {
+    const document = this.openedDocuments.get(uri);
+    await document?.resendDiagnostics();
   }
 
   onWillSaveTextDocument(params: WillSaveTextDocumentParams): void {

--- a/server/src/ZetaSqlWrapper.ts
+++ b/server/src/ZetaSqlWrapper.ts
@@ -265,7 +265,7 @@ export class ZetaSqlWrapper {
 
     let tables = await this.findTableNames(compiledSql);
 
-    const settledResult = await Promise.allSettled(tables.map(t => this.fillTableSchemaFromBq(t)));
+    const settledResult = await Promise.allSettled(tables.filter(t => !this.isTableRegistered(t)).map(t => this.fillTableSchemaFromBq(t)));
     tables = settledResult.filter((v): v is PromiseFulfilledResult<TableDefinition> => v.status === 'fulfilled').map(v => v.value);
 
     for (const table of tables) {

--- a/server/src/ZetaSqlWrapper.ts
+++ b/server/src/ZetaSqlWrapper.ts
@@ -189,8 +189,10 @@ export class ZetaSqlWrapper {
   }
 
   static addColumn(table: SimpleTableProto, newColumn: SimpleColumnProto): void {
-    const column = table.column?.find(c => c.name === newColumn.name);
-    if (!column) {
+    const columnIndex = table.column?.findIndex(c => c.name === newColumn.name);
+    if (table.column && columnIndex !== undefined && columnIndex > -1) {
+      table.column[columnIndex] = newColumn;
+    } else {
       table.column = table.column ?? [];
       table.column.push(newColumn);
     }

--- a/server/src/bigquery/OAuthProfile.ts
+++ b/server/src/bigquery/OAuthProfile.ts
@@ -1,5 +1,6 @@
 import { BigQuery, BigQueryOptions } from '@google-cloud/bigquery';
 import { err, ok, Result } from 'neverthrow';
+import { setTimeout } from 'timers/promises';
 import { DbtDestinationClient } from '../DbtDestinationClient';
 import { DbtProfile, TargetConfig } from '../DbtProfile';
 import { ProcessExecutor } from '../ProcessExecutor';
@@ -97,12 +98,7 @@ export class OAuthProfile implements DbtProfile {
       .then(() => ok(undefined))
       .catch(() => err(OAuthProfile.GCLOUD_AUTHENTICATION_ERROR));
 
-    const timeoutPromise = new Promise<Result<void, string>>(resolve => {
-      setTimeout(() => {
-        resolve(err(OAuthProfile.GCLOUD_AUTHENTICATION_TIMEOUT_ERROR));
-      }, OAuthProfile.GCLOUD_AUTHENTICATION_TIMEOUT);
-    });
-
+    const timeoutPromise = setTimeout(OAuthProfile.GCLOUD_AUTHENTICATION_TIMEOUT, err(OAuthProfile.GCLOUD_AUTHENTICATION_TIMEOUT_ERROR));
     return Promise.race([authenticatePromise, timeoutPromise]);
   }
 

--- a/server/src/dbt_execution/DbtRpc.ts
+++ b/server/src/dbt_execution/DbtRpc.ts
@@ -65,8 +65,8 @@ export class DbtRpc extends Dbt {
     const result = await this.dbtRpcClient.compile();
     console.log(
       result?.result.request_token !== undefined
-        ? 'Initial compilation finished successfully'
-        : `Initial compilation finished with error ${result?.error?.data?.message ?? 'undefined'}`,
+        ? 'Initial compilation started successfully'
+        : `There was an error while starting the compilation: ${result?.error?.data?.message ?? 'undefined'}`,
     );
   }
 

--- a/server/src/dbt_execution/DbtRpcClient.ts
+++ b/server/src/dbt_execution/DbtRpcClient.ts
@@ -138,7 +138,10 @@ export class DbtRpcClient {
 
   async makePostRequest<T extends Response>(postData: PostData): Promise<T | undefined> {
     try {
-      const response = await axios.post<T>(`http://localhost:${String(this.port)}/jsonrpc`, postData, { timeout: this.postRequestTimeout });
+      const response = await axios.post<T>(`http://localhost:${String(this.port)}/jsonrpc`, postData, {
+        timeout: this.postRequestTimeout,
+        headers: { 'Content-Type': 'application/json' },
+      });
       return response.data;
     } catch (e) {
       console.log(`Error while sending request ${JSON.stringify(postData)}: ${e instanceof Error ? e.message : String(e)}`);

--- a/server/src/dbt_execution/DbtRpcServer.ts
+++ b/server/src/dbt_execution/DbtRpcServer.ts
@@ -75,6 +75,7 @@ export class DbtRpcServer {
     return this.startDeferred.promise;
   }
 
+  /** Compilation can be started after server received SIGHUP signal */
   async ensureCompilationFinished(): Promise<void> {
     return new Promise((resolve, reject) => {
       const intervalId = setInterval(async () => {

--- a/server/src/document/DbtTextDocument.ts
+++ b/server/src/document/DbtTextDocument.ts
@@ -299,11 +299,11 @@ export class DbtTextDocument {
       );
       const astResult = await this.destinationState.bigQueryContext.analyzeTable(originalFilePath, compiledSql);
       if (astResult.isOk()) {
-        console.log(`AST was successfully received for ${originalFilePath}`);
+        console.log(`AST was successfully received for ${originalFilePath}`, LogLevel.Debug);
         this.ast = astResult.value;
       } else {
-        console.log(`There was an error while parsing ${originalFilePath}`);
-        console.log(astResult);
+        console.log(`There was an error while parsing ${originalFilePath}`, LogLevel.Debug);
+        console.log(astResult, LogLevel.Debug);
       }
       [rawDocDiagnostics, compiledDocDiagnostics] = this.diagnosticGenerator.getDiagnosticsFromAst(
         astResult,

--- a/server/src/document/DbtTextDocument.ts
+++ b/server/src/document/DbtTextDocument.ts
@@ -201,7 +201,7 @@ export class DbtTextDocument {
   }
 
   async resendDiagnostics(): Promise<void> {
-    if (this.destinationState.contextInitialized && !this.currentDbtError) {
+    if (this.destinationState.contextInitialized && this.dbt.dbtReady && !this.currentDbtError && !this.modelCompiler.compilationInProgress) {
       await this.updateDiagnostics();
     }
   }

--- a/server/src/document/DbtTextDocument.ts
+++ b/server/src/document/DbtTextDocument.ts
@@ -200,6 +200,12 @@ export class DbtTextDocument {
     }
   }
 
+  async resendDiagnostics(): Promise<void> {
+    if (this.destinationState.contextInitialized && !this.currentDbtError) {
+      await this.updateDiagnostics();
+    }
+  }
+
   debouncedCompile = debounce(async () => {
     this.progressReporter.sendStart(this.rawDocument.uri);
     await this.modelCompiler.compile(this.getModelPathOrFullyQualifiedName());

--- a/server/src/test/helper.ts
+++ b/server/src/test/helper.ts
@@ -2,6 +2,7 @@ import { ok } from 'assert';
 import { assertThat, defined, not } from 'hamjest';
 import { err } from 'neverthrow';
 import * as path from 'path';
+import { setTimeout } from 'timers/promises';
 import { instance, mock, when } from 'ts-mockito';
 import { CompletionItem } from 'vscode-languageserver';
 import { DbtNodeCompletionProvider } from '../completion/DbtCompletionProvider';
@@ -61,9 +62,7 @@ export function shouldPassValidProfile(config: string, profileName: string): voi
 }
 
 export function sleep(ms: number): Promise<unknown> {
-  return new Promise(resolve => {
-    setTimeout(resolve, ms);
-  });
+  return setTimeout(ms);
 }
 
 export function shouldNotProvideCompletions(completionProvider: DbtNodeCompletionProvider, jinjaPartType: JinjaPartType, text: string): void {


### PR DESCRIPTION
- We now analyze sql more often. We do it on each active document change, and we do it for current active document if ZetaSQL catalog changed.
- Added client logger
- Fixed issue when it was possible to run two language servers for one project.
- Fixed issue with duplicated udfs in catalog.
- Increased timeouts for fixing several flaky tests.
- Fixed problem with initial compilation. Sometimes it didn't work since we often send SIGHUP signal to RPC server.