### PR TITLE
Register the EXTERNAL_QUERY tvf

### DIFF
--- a/server/src/ZetaSqlApi.ts
+++ b/server/src/ZetaSqlApi.ts
@@ -104,6 +104,8 @@ export class ZetaSqlApi {
         const featuresForVersion = await this.zetaSql.LanguageOptions.getLanguageFeaturesForVersion(LanguageVersion.VERSION_CURRENT);
         featuresForVersion.forEach(f => options.enableLanguageFeature(f));
         options.enableLanguageFeature(LanguageFeature.FEATURE_NAMED_ARGUMENTS);
+        options.enableLanguageFeature(LanguageFeature.FEATURE_CREATE_TABLE_FUNCTION);
+        options.enableLanguageFeature(LanguageFeature.FEATURE_CREATE_EXTERNAL_TABLE_WITH_CONNECTION);
         options.enableLanguageFeature(LanguageFeature.FEATURE_JSON_TYPE);
         options.enableLanguageFeature(LanguageFeature.FEATURE_JSON_VALUE_EXTRACTION_FUNCTIONS);
         options.enableLanguageFeature(LanguageFeature.FEATURE_INTERVAL_TYPE);

--- a/server/src/ZetaSqlWrapper.ts
+++ b/server/src/ZetaSqlWrapper.ts
@@ -71,6 +71,7 @@ export abstract class ZetaSqlWrapper {
         { name: 'tinyint', type: { typeKind: TypeKind.TYPE_INT64 } },
         { name: 'byteint', type: { typeKind: TypeKind.TYPE_INT64 } },
       ],
+      customTvf: [{ namePath: ['external_query'], argumentName: ['connection_id', 'external_database_query', 'options'] }],
     };
   }
 


### PR DESCRIPTION
Hello. I meant to open this PR into my personal fork, but I will leave it here in case anyone else is ever interested in this.
The dbt project (BigQuery based) that I use this language server on utilizes a lot of EXTERNAL_QUERY's. 
https://cloud.google.com/bigquery/docs/reference/standard-sql/federated_query_functions#external_query


The language server throws errors that say "Table-valued function not found: EXTERNAL_QUERY". 
This PR fixes the errors. 
If someone else wants to help me think through how to deliver this in a smarter/more thorough way I would be happy hear it. Thanks for this great plugin!