### PR TITLE
Pass on alias to function call arguments

### DIFF
--- a/server/src/ZetaSqlParser.ts
+++ b/server/src/ZetaSqlParser.ts
@@ -130,7 +130,7 @@ export class ZetaSqlParser {
         break;
       }
       case 'astFunctionCallNode': {
-        node.astFunctionCallNode?.arguments.forEach(c => columns.push(...this.getColumns(c)));
+        node.astFunctionCallNode?.arguments.forEach(c => columns.push(...this.getColumns(c, alias)));
         break;
       }
       default: {


### PR DESCRIPTION
(continuation of #1221) Pass the alias to function call arguments such that the alias is also recorded for the columns passed as arguments.