### PR TITLE
Add withQuery to autocomplete and fixes to column suggestions

### DIFF
--- a/server/src/ZetaSqlAst.ts
+++ b/server/src/ZetaSqlAst.ts
@@ -459,7 +459,7 @@ export interface CompletionInfo {
   withSubqueries: Map<string, WithSubqueryInfo>;
 }
 
-interface WithSubqueryInfo {
+export interface WithSubqueryInfo {
   columns: ResolvedColumn[];
   parseLocationRange?: Location;
 }

--- a/server/src/completion/CompletionProvider.ts
+++ b/server/src/completion/CompletionProvider.ts
@@ -1,15 +1,20 @@
-import { AnalyzeResponse__Output } from '@fivetrandevelopers/zetasql/lib/types/zetasql/local_service/AnalyzeResponse';
 import { CompletionItem, CompletionParams, Position, Range } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { DbtRepository } from '../DbtRepository';
 import { DestinationContext } from '../DestinationContext';
 import { JinjaParser, JinjaPartType } from '../JinjaParser';
-import { DbtTextDocument } from '../document/DbtTextDocument';
+import { DbtTextDocument, QueryParseInformation } from '../document/DbtTextDocument';
 import { DiffUtils } from '../utils/DiffUtils';
-import { comparePositions, getIdentifierRangeAtPosition } from '../utils/Utils';
+import { comparePositions } from '../utils/Utils';
 import { DbtCompletionProvider } from './DbtCompletionProvider';
 import { SnippetsCompletionProvider } from './SnippetsCompletionProvider';
 import { SqlCompletionProvider } from './SqlCompletionProvider';
+import { getWordRangeAtPosition } from '../utils/TextUtils';
+import { AnalyzeResponse__Output } from '@fivetrandevelopers/zetasql/lib/types/zetasql/local_service/AnalyzeResponse';
+
+// string[] is a better signature but this way TS doesn't throw an error
+// when using `arr[1] ?? arr[0]`
+export type CompletionTextInput = [string, string | undefined];
 
 export class CompletionProvider {
   sqlCompletionProvider = new SqlCompletionProvider();
@@ -26,14 +31,19 @@ export class CompletionProvider {
     this.dbtCompletionProvider = new DbtCompletionProvider(dbtRepository);
   }
 
-  async provideCompletionItems(completionParams: CompletionParams, ast?: AnalyzeResponse__Output): Promise<CompletionItem[]> {
+  async provideCompletionItems(
+    completionParams: CompletionParams,
+    ast?: AnalyzeResponse__Output,
+    queryInformation?: QueryParseInformation,
+  ): Promise<CompletionItem[]> {
     const dbtCompletionItems = this.provideDbtCompletions(completionParams);
     if (dbtCompletionItems) {
       return dbtCompletionItems;
     }
-    const text = this.getCompletionText(completionParams);
-    const snippetItems = this.snippetsCompletionProvider.provideSnippets(text);
-    const sqlItems = await this.provideSqlCompletions(completionParams, text, ast);
+    const completionText = this.getCompletionText(completionParams);
+    const [tableOrColumn, column] = completionText;
+    const snippetItems = this.snippetsCompletionProvider.provideSnippets(column ?? tableOrColumn);
+    const sqlItems = await this.provideSqlCompletions(completionParams, completionText, ast, queryInformation);
     return [...snippetItems, ...sqlItems];
   }
 
@@ -56,31 +66,48 @@ export class CompletionProvider {
     return undefined;
   }
 
-  private async provideSqlCompletions(completionParams: CompletionParams, text: string, ast?: AnalyzeResponse__Output): Promise<CompletionItem[]> {
+  private async provideSqlCompletions(
+    completionParams: CompletionParams,
+    text: CompletionTextInput,
+    ast?: AnalyzeResponse__Output,
+    queryInformation?: QueryParseInformation,
+  ): Promise<CompletionItem[]> {
     if (this.destinationContext.isEmpty()) {
       return [];
     }
+
+    let aliases: Map<string, string> | undefined;
 
     let completionInfo = undefined;
     if (ast) {
       const line = DiffUtils.getOldLineNumber(this.compiledDocument.getText(), this.rawDocument.getText(), completionParams.position.line);
       const offset = this.compiledDocument.offsetAt(Position.create(line, completionParams.position.character));
       completionInfo = DbtTextDocument.ZETA_SQL_AST.getCompletionInfo(ast, offset);
+
+      aliases = queryInformation?.selects.find(s => offset >= s.parseLocationRange.start && offset <= s.parseLocationRange.end)?.tableAliases;
     }
+
     return this.sqlCompletionProvider.onSqlCompletion(
       text,
       completionParams,
       this.destinationContext.destinationDefinition,
       completionInfo,
       this.destinationContext.getDestination(),
+      aliases,
     );
   }
 
-  private getCompletionText(completionParams: CompletionParams): string {
+  private getCompletionText(completionParams: CompletionParams): CompletionTextInput {
     const previousPosition = Position.create(
       completionParams.position.line,
       completionParams.position.character > 0 ? completionParams.position.character - 1 : 0,
     );
-    return this.rawDocument.getText(getIdentifierRangeAtPosition(previousPosition, this.rawDocument.getText()));
+
+    return this.rawDocument
+      .getText(
+        getWordRangeAtPosition(previousPosition, /[.|\w|`]+/, this.rawDocument.getText().split('\n')) ??
+          Range.create(previousPosition, previousPosition),
+      )
+      .split('.') as CompletionTextInput;
   }
 }

--- a/server/src/document/DbtTextDocument.ts
+++ b/server/src/document/DbtTextDocument.ts
@@ -400,6 +400,7 @@ export class DbtTextDocument {
     return this.completionProvider.provideCompletionItems(
       completionParams,
       this.analyzeResult?.ast.isOk() ? this.analyzeResult.ast.value : undefined,
+      this.queryInformation,
     );
   }
 


### PR DESCRIPTION
Fixes a few issues:
- The with queries referenced in a table were not taken into account as sources when using autocomplete.
- Aliases were not used in autocomplete, leading some to not match with what the user typed
- (not sure if this was intentional) Triggering column-only suggestions should happen both when the user presses `.` **and** when the user presses the autocomplete shortcut when positioned just after a `.` (such as `users.|` where `|` is the cursor).